### PR TITLE
Allow trestle-cmd chmod to fail

### DIFF
--- a/.github/actions/trestle-cmd/action.yml
+++ b/.github/actions/trestle-cmd/action.yml
@@ -13,7 +13,7 @@ runs:
   steps:
     - name: Enable writing to trestle directories
       shell: bash
-      run: chmod -R a+w $GITHUB_WORKSPACE/doc/compliance/oscal
+      run: chmod -R a+w $GITHUB_WORKSPACE/doc/compliance/oscal || true
 
     - name: Run cmd
       shell: bash


### PR DESCRIPTION
chmod was failing on the second time the action is called in a single job. Ignore that failure since it happens after we've gotten the directories properly marked.