### PR TITLE
Hidden files should be a warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,12 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
+  after_action :verify_pundit_authorization, unless: :devise_controller?
   around_action :switch_locale
 
   def switch_locale(&action)
     locale = params[:locale] || I18n.default_locale
     I18n.with_locale(locale, &action)
   end
-  include Pundit::Authorization
-  after_action :verify_pundit_authorization, unless: :devise_controller?
 
   def verify_pundit_authorization
     if action_name == "index"

--- a/zap.conf
+++ b/zap.conf
@@ -94,7 +94,7 @@
 40029	WARN	(Trace.axd Information Leak - Active/beta)
 40032	FAIL	(.htaccess Information Leak - Active/release)
 40034	FAIL	(.env Information Leak - Active/beta)
-40035	FAIL	(Hidden File Finder - Active/beta)
+40035	WARN	(Hidden File Finder - Active/beta)
 41	FAIL	(Source Code Disclosure - Git  - Active/beta)
 42	WARN	(Source Code Disclosure - SVN - Active/beta)
 43	WARN	(Source Code Disclosure - File Inclusion - Active/beta)


### PR DESCRIPTION
top-level hidden file requests are returning a 200 status, but with the content of the home page, not the hidden file. Not ideal, but not dangerous